### PR TITLE
Add required packages in setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-pandas>=0.20.0
-requests>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
 	name = "arcospy",
-	version = "1.3.5",
+	version = "1.3.6",
 	author = "Python translator: Jeffery Sauer. Original R Package Authors: Washington Post Data Investigations Team",
 	author_email = "jcsauer@terpmail.umd.edu",
 	description = "Python version of the R arcos package",

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,8 @@ setuptools.setup(
 		"Operating System :: OS Independent",
 	],
 	python_requires = '>=3.6',
+        install_requires = [
+            'pandas>=0.20.0',
+            'requests>=2.0.0'
+        ],
 )


### PR DESCRIPTION
This PR adds `pandas` and `requests` to the setup file so they are installed (if not already) when `arcospy` is installed. 

If one installs `arcospy` with pip into an environment without pandas or requests, everything will look successful until they run `import arcospy`, at which point they will find they are missing dependencies. This change will ensure those packages are installed at the same time `arcospy` is installed. 

They are in the `requirements.txt` file, yes, but not everyone will be starting off with a clone of this repo. They may have been told "just install arcospy from pip" and so they run a single command in their existing project: `pip install arcospy` and expect to get underway. Their project folder may already have a `requirements.txt` detailing their own environment for the project; perhaps they have even pinned a different version of pandas for whatever reason. 

I do not know if this generalizes to R users, but in my experience this is a more pythonic way to ship a package. 